### PR TITLE
fix: decode chains folder path URI before use 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ const objectHasAllKeys = (obj, keysArray) =>
 
 let supportedChains = [];
 // eslint-disable-next-line no-undef
-const chainsFolder = `${path.dirname(import.meta.url)}/chains/`.replace('file://', '');
+const chainsFolder = `${path.dirname(decodeURIComponent(import.meta.url))}/chains/`.replace('file://', '');
 filesList(chainsFolder).forEach((item) => {
   const name = item.replace(chainsFolder, '').replace('.json', '');
   supportedChains.push(name);


### PR DESCRIPTION
Fixes a bug where code fails when there are spaces in the node path:

```
❯ cw
node:fs:1451
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, scandir '/Users/nd0ut/Library/Application%20Support/fnm/node-versions/v18.13.0/installation/lib/node_modules/@yerofey/cryptowallet-cli/src/chains/'
    at readdirSync (node:fs:1451:3)
    at filesList (file:///Users/nd0ut/Library/Application%20Support/fnm/node-versions/v18.13.0/installation/lib/node_modules/@yerofey/cryptowallet-cli/src/utils.js:8:10)
    at file:///Users/nd0ut/Library/Application%20Support/fnm/node-versions/v18.13.0/installation/lib/node_modules/@yerofey/cryptowallet-cli/src/utils.js:38:1
    at ModuleJob.run (node:internal/modules/esm/module_job:194:25) {
  errno: -2,
  syscall: 'scandir',
  code: 'ENOENT',
  path: '/Users/nd0ut/Library/Application%20Support/fnm/node-versions/v18.13.0/installation/lib/node_modules/@yerofey/cryptowallet-cli/src/chains/'
}

Node.js v18.13.0
```